### PR TITLE
fix: apply pnl capital spread by absolute position

### DIFF
--- a/tea-bond/src/pnl/mod.rs
+++ b/tea-bond/src/pnl/mod.rs
@@ -119,8 +119,8 @@ where
                             .map(|t| settle_time.signed_duration_since(t).num_days() as f64)
                             .unwrap_or(0.);
                         state.capital -= duration_days
-                            * (last_capital_rate + state.avg_capital_spread)
-                            * state.pos
+                            * (last_capital_rate * state.pos
+                                + state.avg_capital_spread * state.pos.abs())
                             * bond.par_value
                             * multiplier
                             / 365.;


### PR DESCRIPTION
## Summary
- Apply capital spread cost by absolute position in bond PnL capital accrual
- Keep base capital rate directional while treating TRS spread as a cost on exposure

## Tests
- cargo test -p tea-bond --features pnl
- cargo fmt --check --package tea-bond (fails on pre-existing formatting in tea-bond/src/pnl/trade_from_signal.rs)